### PR TITLE
add th10_patch_autobomb

### DIFF
--- a/twinhook/control/th10_player.cpp
+++ b/twinhook/control/th10_player.cpp
@@ -144,7 +144,7 @@ void th10_player::doPowerupPoll()
 	for (int i = 0; i < 2000; i++)
 	{
 		int eax = *(int*)(ebp + 0x2c);
-		if (eax)
+		if (eax == 1)
 		{
 			float x = *(float*)(ebp - 0x4);
 			float y = *(float*)ebp;

--- a/twinhook/patch/th10_patch_autobomb.cpp
+++ b/twinhook/patch/th10_patch_autobomb.cpp
@@ -1,0 +1,18 @@
+#include "../stdafx.h"
+#include "th10_patch_autobomb.h"
+
+void th10_patch_autobomb::patch()
+{
+	HANDLE hProcess = GetCurrentProcess();
+	WriteProcessMemory(hProcess, (void*)0x00425C13,
+		"\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90",
+		13, NULL);
+}
+
+void th10_patch_autobomb::unpatch()
+{
+	HANDLE hProcess = GetCurrentProcess();
+	WriteProcessMemory(hProcess, (void*)0x00425C13,
+		"\xF6\x05\x5C\x4E\x47\x00\x02\x0F\x84\x52\x01\x00\x00",
+		13, NULL);
+}

--- a/twinhook/patch/th10_patch_autobomb.h
+++ b/twinhook/patch/th10_patch_autobomb.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "th_patch.h"
+
+class th10_patch_autobomb : th_patch
+{
+public:
+	void patch() override;
+	void unpatch() override;
+};


### PR DESCRIPTION
In line 147 of twinhook/control/th10_player.cpp.
If the variable eax is not equal to zero, some items (not powerups) will be added into the vector when the boss is defeated or player uses a bomb. These items will influence bot to make judgments.

if eax is equal to 1, only powerups will be added into the vector.

==================================================================

Add th10_patch_autobomb()